### PR TITLE
Remove rtabmap

### DIFF
--- a/scripts/relay_rtabmap_grid_prob_map.sh
+++ b/scripts/relay_rtabmap_grid_prob_map.sh
@@ -1,1 +1,0 @@
-ros2 run topic_tools relay /rtabmap/grid_prob_map /map

--- a/scripts/rtabmap_start.sh
+++ b/scripts/rtabmap_start.sh
@@ -1,1 +1,0 @@
-ros2 launch rtabmap_launch rtabmap.launch.py   rtabmap_args:=--delete_db_on_start   rgb_topic:=/image   depth_topic:=/depth/image_rect_raw   camera_info_topic:=/camera_info   approx_sync:=true   subscribe_stereo:=false   visual_odometry:=true   publish_tf_map:=true  rtabmapviz:=true   rviz:=true

--- a/src/rovr_control/package.xml
+++ b/src/rovr_control/package.xml
@@ -26,7 +26,6 @@
   <exec_depend>ros2launch</exec_depend>
   <exec_depend>motor_control</exec_depend>
   <exec_depend>joy</exec_depend>
-  <exec_depend>rtabmap_ros</exec_depend>
   <exec_depend>python3-serial</exec_depend>
   <exec_depend>rovr_interfaces</exec_depend>
 


### PR DESCRIPTION
Removed rtabmap_ros as a rovr_control dependency and added boost as a ros2socketcan_bridge dependency so it can build without rtabmap_ros.