### PR TITLE
Can setup instrutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ mttcan
 
 sudo ip link set can0 up type can bitrate 500000
 sudo ip link set can1 up type can bitrate 500000
-
 ```
 
 4: Run the command "sudo crontab -e" and put this line in the file that appears:
@@ -136,21 +135,21 @@ sudo ip link set can1 up type can bitrate 500000
 @reboot sleep 5 && echo 'robot' | sudo -S sh /can_startup.sh 2>&1 | logger -t mycmd
 ```
 
-And that should work. If it dosen't and you need to read the output of the crontab, use this command:
+And that should work. If it doesn't and you need to read the output of the crontab, use this command:
 
 ```
 sudo grep 'mycmd' /var/log/syslog
 ```
 
-## GStreamer Resources/References
-
-[Accelerated GStreamer Guide](https://docs.nvidia.com/jetson/archives/r35.2.1/DeveloperGuide/text/SD/Multimedia/AcceleratedGstreamer.html)
-
-## Jetson HDD
+## Jetson External HDD Commands
 
 ```
-    sudo service docker stop
+sudo service docker stop
 sudo mv /var/lib/docker /hd/docker
 sudo ln -s /hd/docker /var/lib/docker # Create a symbolic link
 sudo service docker start
 ```
+
+## GStreamer Resources/References
+
+[Accelerated GStreamer Guide](https://docs.nvidia.com/jetson/archives/r35.2.1/DeveloperGuide/text/SD/Multimedia/AcceleratedGstreamer.html)

--- a/README.md
+++ b/README.md
@@ -107,6 +107,50 @@ gst-launch-1.0 udpsrc port=5000 ! application/x-rtp, encoding-name=H264, payload
 
 [VESC Control with CAN](https://dongilc.gitbook.io/openrobot-inc/tutorials/control-with-can)
 
+To load the CAN modules at startup do the following:
+
+1: Put the following in a .conf file in /modules-load.d/
+
+```
+#Setting up the CAN bus 
+can
+can_raw
+mttcan
+#eof
+```
+
+2: Find the file /etc/modprobe.d/denylist-mttcan.conf and either delete it or comment out the one line in it (The filename might be .../blacklist-mttcan.conf)
+
+3: Make a script called "can_startup.sh" in the root directory for the system, with the following contents:
+```
+#! /usr/bin/sh
+
+sudo ip link set can0 up type can bitrate 500000
+sudo ip link set can1 up type can bitrate 500000
+
+```
+
+4: Run the command "sudo crontab -e" and put this line in the file that appears:
+
+```
+@reboot sleep 5 && echo 'robot' | sudo -S sh /can_startup.sh 2>&1 | logger -t mycmd
+```
+
+And that should work. If it dosen't and you need to read the output of the crontab, use this command:
+
+```
+sudo grep 'mycmd' /var/log/syslog
+```
+
 ## GStreamer Resources/References
 
 [Accelerated GStreamer Guide](https://docs.nvidia.com/jetson/archives/r35.2.1/DeveloperGuide/text/SD/Multimedia/AcceleratedGstreamer.html)
+
+## Jetson HDD
+
+```
+    sudo service docker stop
+sudo mv /var/lib/docker /hd/docker
+sudo ln -s /hd/docker /var/lib/docker # Create a symbolic link
+sudo service docker start
+```


### PR DESCRIPTION
Changes to readme to explain how to setup the CAN bus on startup for jetson orin