### PR TITLE
Absolute encoder fixes

### DIFF
--- a/config/drivetrain_config.yaml
+++ b/config/drivetrain_config.yaml
@@ -3,3 +3,7 @@ drivetrain_node:
         HALF_WHEEL_BASE: 0.7127  # HALF of the wheelbase in meters # TODO: Verify this on the final robot
         HALF_TRACK_WIDTH: 0.36585  # HALF of the trackwidth in meters # TODO: Verify this on the final robot
         STEERING_MOTOR_GEAR_RATIO: 20 # TODO: Ask mechanical what this value will be on the real robot
+        FRONT_LEFT_MAGNET_OFFSET: 0 # TODO: Calibrate this on the final robot
+        FRONT_RIGHT_MAGNET_OFFSET: 0 # TODO: Calibrate this on the final robot
+        BACK_LEFT_MAGNET_OFFSET: 0 # TODO: Calibrate this on the final robot
+        BACK_RIGHT_MAGNET_OFFSET: 0 # TODO: Calibrate this on the final robot


### PR DESCRIPTION
Converted from 32-bit binary reading to a measurement in degrees, also added magnet offset constants for each of the encoders that we will need to calibrate on the real robot.