### PR TITLE
Devcontainer as isaac ros

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,1 +1,0 @@
-FROM umnrobotics/isaac_ros:latest

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,25 +1,33 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
 {
-	"name": "Existing Dockerfile",
-	"build": {
-		// Sets the run context to one level up instead of the .devcontainer folder.
-		// "context": "..",
-		// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
-		"dockerfile": "Dockerfile"
-	},
-	// TODO: fix these to somehow sync with isaac_ros
+	"name": "UMN Lunabotics",
+	"image": "umnrobotics/isaac_ros",
 	"runArgs": [
 		"--privileged",
-		"--env=DISPLAY=${localEnv:DISPLAY}"
+		"--network",
+		"host"
 	],
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-	"initializeCommand": "git config --global --add safe.directory /workspaces/Lunabotics-2024 && git reset --soft && git submodule update --init --recursive && git config --global submodule.recurse true && git pull",
-	"postCreateCommand": "echo 'source /opt/ros/humble/setup.bash' >> ~/.bashrc",
+	"containerEnv": {
+		"DISPLAY": "${localEnv:DISPLAY}",
+		"NVIDIA_VISIBLE_DEVICES": "all",
+		"NVIDIA_DRIVER_CAPABILITIES": "all",
+		"FASTFASTRTPS_DEFAULT_PROFILES_FILE": "/usr/local/share/middleware_profiles/rtps_udp_profile.xml",
+		// "ROS_DOMAIN_ID": "${localEnv:ROS_DOMAIN_ID}"
+	},
+	"initializeCommand": "git config --global --add safe.directory /workspaces/Lunabotics-2024 && git reset --soft && git submodule update --init --recursive && git config --global submodule.recurse true && git pull || true",
+	"postCreateCommand": "echo 'source /opt/ros/humble/setup.bash' >> ~/.bashrc && echo 'source /workspaces/Lunabotics-2024/install/setup.bash' >> ~/.bashrc",
 	"postStartCommand": "sudo apt-get update && rosdep update && rosdep install -i --from-path src --rosdistro $ROS_DISTRO -y --skip-keys 'nvblox'",
+	// "mounts": [
+	// 	"type=bind,source=/tmp/.X11-unix,target=/tmp/.X11-unix",
+	// 	"type=bind,source=${localEnv:HOME}/.Xauthority,target=/home/admin/.Xauthority",
+	// 	"type=bind,source=/usr/local/zed/resources,target=/usr/local/zed/resources",
+	// 	"type=bind,source=/ssd,target=/ssd",
+	// 	"type=bind,source=/usr/local/zed/settings,target=/usr/local/zed/settings",
+	// 	"type=bind,source=${localWorkspaceFolder},target=/workspaces/isaac_ros-dev",
+	// 	"type=bind,source=/dev,target=/dev",
+	// 	"type=bind,source=/etc/localtime,target=/etc/localtime,readonly"
+	// ],
 	// Configure tool-specific properties.
 	"customizations": {
 		"vscode": {
@@ -28,12 +36,10 @@
 				"ms-vscode.cpptools-extension-pack",
 				"VisualStudioExptTeam.vscodeintellicode",
 				"ms-python.python",
-				"donjayamanne.python-extension-pack",
-				"ms-python.black-formatter",
-				"charliermarsh.ruff",
+				"ms-python.isort",
+				"charliermarsh.ruff@prerelease",
 				"wayou.vscode-todo-highlight",
-				"ms-azuretools.vscode-docker",
-				"nonanonno.vscode-ros2"
+				"ms-iot.vscode-ros@prerelease"
 			],
 			"settings": {
 				"git.autofetch": true,
@@ -41,22 +47,38 @@
 				"files.autoSave": "afterDelay",
 				"editor.formatOnSave": true,
 				"[python]": {
-					"editor.defaultFormatter": "ms-python.black-formatter",
-					"editor.codeActionsOnSave": {
-						"source.fixAll": true
-					}
+					"editor.formatOnPaste": false,
+					"editor.formatOnSaveMode": "file"
+				},
+				"[workbench.view.extension]": {
+					"ms-python.python": false
 				},
 				"black-formatter.args": [
 					"--line-length",
 					"120"
 				],
-				"ruff.lint.args": [
-					"--ignore=E501" // Ignore line too long
-				],
-				"[c++]": {
-					"editor.defaultFormatter": "ms-vscode.cpptools"
+				"[C_Cpp]": {
+					"default.cppStandard": "c++17",
+					"default.cStandard": "c99"
 				},
-				"C_Cpp.clang_format_fallbackStyle": "{ ColumnLimit: 120 }"
+				"ruff.lineLength": 99,
+				"ruff.lint.enable": true,
+				"ruff.format.args": [
+					"line-length=99"
+				],
+				"ruff.lint.select": [
+					"A",
+					"C",
+					"CNL",
+					"D",
+					"E",
+					"F",
+					"I",
+					"Q",
+					"W"
+				],
+				"ruff.nativeServer": true,
+				"C_Cpp.clang_format_fallbackStyle": "Google"
 			}
 		}
 	},

--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,8 @@ rosbags/
 # eclipse stuff
 .project
 .cproject
-.vscode
+.vscode/*
+!.vscode/tasks.json
 
 # qcreator stuff
 CMakeLists.txt.user
@@ -56,3 +57,4 @@ qtcreator-*
 CATKIN_IGNORE
 
 .fake
+

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,38 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Build All Task",
+            "type": "colcon",
+            "args": [
+                "build",
+                "--symlink-install"
+            ],
+            "problemMatcher": [],
+            "group": "build"
+        },
+        {
+            "label": "Build No GPU Task",
+            "type": "colcon",
+            "args": [
+                "build",
+                "--symlink-install",
+                "--packages-up-to",
+                "rovr_control",
+                "motor_control",
+                "ros2socketcan_bridge"
+            ],
+            "problemMatcher": [],
+            "group": "build"
+        },
+        {
+            "label": "Test All",
+            "type": "colcon",
+            "args": [
+                "test"
+            ],
+            "problemMatcher": [],
+            "group": "test"
+        },
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -47,20 +47,23 @@ graph LR
 Open vscode then press ctrl+shift+p and type "Clone Repository in Container Volume". Select "Dev Containers: Clone Repository in Container Volume" and then select "Clone a repository from GitHub in a Container Volume". Search for and select our Lunabotics-2024 repository.
 <br><br>
 
-After opening the container, run the following commands in the terminal:
-```
-source /opt/ros/humble/setup.bash
-colcon build --symlink-install
-source install/setup.bash
-```
-
-If your machine does not have an Nvidia GPU, select only the packages you want like this:
+If your machine does not have an Nvidia GPU or you haven't set it up with [container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html), run the following commands in the Command Palette (Ctrl + Shift + P):
 
 ```
-colcon build --symlink-install --packages-up-to rovr_control motor_control ros2socketcan_bridge
+Tasks: Configure Default Build Task
+Build No GPU Tasks
 ```
 
+After opening the container, run the following commands in the Command Palette (Ctrl + Shift + P):
+```
+Tasks: Run Build Task
+```
+</details>
+<details>
+<summary>Updating Dev Container For Windows/Mac</summary>
+<br>
 If you ever need to rebuild the remote container image, first update the x86_64 and aarch64 images:
+
 ```
 cd ~/Lunabotics-2024/src/isaac_ros/isaac_ros_common/docker
 
@@ -88,29 +91,48 @@ devcontainer build --push true --workspace-folder . --platform="linux/amd64,linu
 </details>
 
 <details>
-<summary>How to Run Inside ISAAC ROS Container On Linux/Jetson</summary>
+<summary>How to Run Inside ISAAC ROS Container/Dev Container On Linux/Jetson</summary>
 <br>
-1a.) First, do the following before running run_dev.sh:
+First, do the following before running run_dev.sh:
 
 ```
 printf "CONFIG_IMAGE_KEY=ros2_humble.realsense.deepstream.user.zed.umn \n" > ~/Lunabotics-2024/src/isaac_ros/isaac_ros_common/scripts/.isaac_ros_common-config 
 ``` 
-1b.) To use Gazebo in the ISAAC ROS container, do this instead:
+To use Gazebo in the ISAAC ROS container, do this instead:
 
 ```
 printf "CONFIG_IMAGE_KEY=ros2_humble.realsense.deepstream.user.zed.umn.gazebo \n" > ~/Lunabotics-2024/src/isaac_ros/isaac_ros_common/scripts/.isaac_ros_common-config 
 ``` 
-2.) To make it so zed modules won't rerun every time you start the container, do this:
+<details>
+<summary>Regular Container</summary>
+<br>
+To make it so zed modules won't rerun every time you start the container, do this:
 
 ```
 echo "-v /usr/local/zed/resources:/usr/local/zed/resources -v /ssd:/ssd" > ~/Lunabotics-2024/src/isaac_ros/isaac_ros_common/scripts/.isaac_ros_dev-dockerargs
 ```
-3.) Then run this command:
+Then run this command:
 
 ```
 cd ~/Lunabotics-2024/src/isaac_ros/isaac_ros_common/docker
 ../scripts/run_dev.sh ~/Lunabotics-2024
 ```
+</details>
+<details>
+<summary>Dev Container</summary>
+<br>
+First run this command to build the container:
+
+```
+../scripts/build_devcontainer_image.sh
+```
+
+Then use Command Palette (Ctrl + Shift + P) to open devcontainer
+```
+>Dev Containers: Reopen in Container
+```
+
+</details>
 It is also worth noting that the docker buildkit doesn't respect Nvidia runtime for building which is needed for zed, so if you set up a new jetson you will need to do one of the following (https://github.com/NVIDIA-ISAAC-ROS/isaac_ros_common/issues/98#issuecomment-1777711989)
 </details>
 

--- a/scripts/build_devcontainer_image.sh
+++ b/scripts/build_devcontainer_image.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto.  Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+ROOT="src/isaac_ros/isaac_ros_common/scripts"
+source $ROOT/utils/print_color.sh
+
+PLATFORM="$(uname -m)"
+BASE_NAME="isaac_ros_dev-$PLATFORM"
+CONTAINER_NAME="$BASE_NAME-container-$USER"
+
+# Read and parse config file if exists
+#
+# CONFIG_IMAGE_KEY (string, can be empty)
+if [[ -f "${ROOT}/.isaac_ros_common-config" ]]; then
+    . "${ROOT}/.isaac_ros_common-config"
+fi
+
+# Build image
+IMAGE_KEY=ros2_humble
+if [[ ! -z "${CONFIG_IMAGE_KEY}" ]]; then
+    IMAGE_KEY=$CONFIG_IMAGE_KEY
+fi
+
+BASE_IMAGE_KEY=$PLATFORM.user
+if [[ ! -z "${IMAGE_KEY}" ]]; then
+    BASE_IMAGE_KEY=$PLATFORM.$IMAGE_KEY
+
+    # If the configured key does not have .user, append it last
+    if [[ $IMAGE_KEY != *".user"* ]]; then
+        BASE_IMAGE_KEY=$BASE_IMAGE_KEY.user
+    fi
+fi
+
+print_info "Building $BASE_IMAGE_KEY base as image: $BASE_NAME using key $BASE_IMAGE_KEY"
+$ROOT/build_base_image.sh $BASE_IMAGE_KEY $BASE_NAME '' '' ''
+
+if [ $? -ne 0 ]; then
+    print_error "Failed to build base image: $BASE_NAME, aborting."
+    exit 1
+fi
+
+docker tag $BASE_NAME umnrobotics/isaac_ros


### PR DESCRIPTION
This PR aims to keep existing functionality of devcontainers for non-nvidia gpu systems, while allowing for the use of devcontainers with isaac_ros to allow for a more feature rich development.
Features Include
- Add ROS vscode extension
    - Add python and c++ LSP
    - Add xacro/urdf preview
    - Add potential for easier automated testing
- Add tasks to allow for building directly in vscode code (no more typing colcon build args...)

Some of this will be redone with isaac-ros 3.0, but its mostly just deleting some stuff like build script