### PR TITLE
Startup script change

### DIFF
--- a/scripts/enter_isaac_ros_container.sh
+++ b/scripts/enter_isaac_ros_container.sh
@@ -3,6 +3,11 @@ printf 'CONFIG_DOCKER_SEARCH_DIRS="$HOME/Lunabotics/src/isaac_ros/isaac_ros_comm
 image_key="ros2_humble.realsense.deepstream.user.zed.umn.gazebo"
 docker_arg="-v /usr/local/zed/resources:/usr/local/zed/resources -v $HOME/rosbags:/rosbags -v /usr/local/zed/settings:/usr/local/zed/settings"
 
-bash ~/Lunabotics/scripts/build_image.sh
+if docker images | grep -q "${image_key}"; then
+    echo "Image ${image_key} already exists"
+else
+    echo "Building image ${image_key}"
+    bash ~/Lunabotics/scripts/build_image.sh
+fi
 
 bash ~/Lunabotics/src/isaac_ros/isaac_ros_common/scripts/run_dev.sh -d ~/Lunabotics -i "${image_key}" -a "${docker_arg}" -v -b


### PR DESCRIPTION
Updated enter_isaac_ros_container script to check if the image already exists before trying to build it from scratch. Running build_image.sh everytime takes substantially longer than checking to see if we need to build it vs just opening the container.