### PR TITLE
Action Server Improvements

### DIFF
--- a/src/drivetrain/drivetrain/drivetrain_node.py
+++ b/src/drivetrain/drivetrain/drivetrain_node.py
@@ -114,10 +114,10 @@ class DrivetrainNode(Node):
 
         # Publish the wheel speeds to the gazebo simulation
         if self.GAZEBO_SIMULATION:
-            self.gazebo_wheel1_pub.publish(Float64(data=leftPower))
-            self.gazebo_wheel2_pub.publish(Float64(data=rightPower))
-            self.gazebo_wheel3_pub.publish(Float64(data=rightPower))
-            self.gazebo_wheel4_pub.publish(Float64(data=leftPower))
+            self.gazebo_wheel1_pub.publish(Float64(data=leftPower * 2))
+            self.gazebo_wheel2_pub.publish(Float64(data=rightPower * 2))
+            self.gazebo_wheel3_pub.publish(Float64(data=rightPower * 2))
+            self.gazebo_wheel4_pub.publish(Float64(data=leftPower * 2))
         return True
 
     def stop(self) -> None:

--- a/src/rovr_control/rovr_control/auto_dig_server.py
+++ b/src/rovr_control/rovr_control/auto_dig_server.py
@@ -27,7 +27,6 @@ class AutoDigServer(AsyncNode):
         self.cli_digger_setPower = self.create_client(SetPower, "digger/setPower")
 
     async def execute_callback(self, goal_handle: ServerGoalHandle):
-        self.cancelled = False  # Reset cancelled flag at the start of the goal
         self.get_logger().info("Starting Autonomous Digging Procedure!")
         result = AutoDig.Result()
 
@@ -62,52 +61,52 @@ class AutoDigServer(AsyncNode):
             return result
 
         # Start the digger belt
-        if not self.cancelled:
+        if not goal_handle.is_cancel_requested:
             self.get_logger().info("Starting the digger belt")
             await self.cli_digger_setPower.call_async(SetPower.Request(power=goal_handle.request.digger_belt_power))
 
         # Lower the digger so that it is just above the ground (get to this position fast)
-        if not self.cancelled:
+        if not goal_handle.is_cancel_requested:
             self.get_logger().info("Lowering the digger to the starting position")
             await self.cli_lift_setPosition.call_async(
                 SetPosition.Request(position=goal_handle.request.lift_digging_start_position)
             )
 
         # Lower the digger into the ground slowly
-        if not self.cancelled:
+        if not goal_handle.is_cancel_requested:
             self.get_logger().info("Lowering the digger into the ground")
             await self.cli_lift_bottom.call_async(Trigger.Request())
 
         # Stay at the lowest position for 5 seconds while digging
-        if not self.cancelled:
+        if not goal_handle.is_cancel_requested:
             self.get_logger().info("Start of Auto Digging in Place")
             await self.async_sleep(5)
             self.get_logger().info("Done Digging in Place")
 
         # Stop digging
-        if not self.cancelled:
+        if not goal_handle.is_cancel_requested:
             self.get_logger().info("Stopping the digger belt")
             await self.cli_digger_stop.call_async(Trigger.Request())
 
         # Raise the digger back up using the lift (get to this position fast)
-        if not self.cancelled:
+        if not goal_handle.is_cancel_requested:
             self.get_logger().info("Raising the digger to the ending position")
             await self.cli_lift_setPosition.call_async(
                 SetPosition.Request(position=goal_handle.request.lift_digging_end_position)
             )
 
         # Raise the digger the rest of the way slowly
-        if not self.cancelled:
+        if not goal_handle.is_cancel_requested:
             self.get_logger().info("Raising the digger up to the top")
             await self.cli_lift_zero.call_async(Trigger.Request())
 
-        if not self.cancelled:
+        if not goal_handle.is_cancel_requested:
             self.get_logger().info("Autonomous Digging Procedure Complete!")
             goal_handle.succeed()
             return result
         else:
             self.get_logger().info("Goal was cancelled")
-            goal_handle.abort()
+            goal_handle.canceled()
             return result
 
     def cancel_callback(self, cancel_request: ServerGoalHandle):

--- a/src/rovr_control/rovr_control/main_control_node.py
+++ b/src/rovr_control/rovr_control/main_control_node.py
@@ -158,6 +158,7 @@ class MainControlNode(Node):
         self.cli_digger_stop.call_async(Trigger.Request())  # Stop the digger belt
         self.cli_drivetrain_stop.call_async(Trigger.Request())  # Stop the drivetrain
         self.cli_lift_stop.call_async(Trigger.Request())  # Stop the digger lift
+        self.cli_dumper_stop.call_async(Trigger.Request())  # Stop the dumper
 
     def end_autonomous(self) -> None:
         """This method returns to teleop control."""

--- a/src/rovr_control/rovr_control/node_util.py
+++ b/src/rovr_control/rovr_control/node_util.py
@@ -7,9 +7,6 @@ class AsyncNode(Node):
     def __init__(self, name: str):
         super().__init__(name)
 
-        # Safety precaution
-        self.cancelled = False
-
         self.sleep_goal_reached = Future()
         self.sleep_goal_reached.set_result(None)
 
@@ -29,7 +26,6 @@ class AsyncNode(Node):
 
     def cancel_callback(self, cancel_request: ServerGoalHandle):
         """This method is called when the action is canceled."""
-        self.cancelled = True
         if not self.sleep_goal_reached.done():
             self.timer.cancel()
             self.timer.destroy()


### PR DESCRIPTION
Removed self.cancelled because it is not necessary (goal_handle.is_cancel_requested already exists for the same purpose!)

I learned about goal_handle.is_cancel_requested from the official ros2 action server examples [here](https://github.com/ros2/examples/blob/master/rclpy/actions/minimal_action_server/examples_rclpy_minimal_action_server/server.py). Note how in this example the main work being done in their execute_callback is a for loop, and every loop iteration they are checking goal_handle.is_cancel_requested to see if they need to return from the execute_callback, so we indeed do need to check if the action is canceled every step of execute_callback, execute_callback doesn't just magically return on its own. And this is indeed in line with what I have noticed while testing, without checks to goal_handle.is_cancel_requested every step, execute_callback will continue running and doing work even after the action is canceled, which is bad.

This PR has been tested on my desktop and everything seems to be working well.