### PR TITLE
Better MAX_POS_DIFF Handling

### DIFF
--- a/src/digger/digger/digger_node.py
+++ b/src/digger/digger/digger_node.py
@@ -72,13 +72,10 @@ class DiggerNode(Node):
 
         # Define default values for our ROS parameters below #
         self.declare_parameter("DIGGER_MOTOR", 3)
-        
         # Assign the ROS Parameters to member variables below #
         self.DIGGER_MOTOR = self.get_parameter("DIGGER_MOTOR").value
-       
         # Print the ROS Parameters to the terminal below #
-        self.get_logger().info("DIGGER_MOTOR has been set to: " + str(self.DIGGER_MOTOR))
-       
+        self.get_logger().info("DIGGER_MOTOR has been set to: " + str(self.DIGGER_MOTOR))       
         # Current state of the digger belt
         self.running = False
         # Current position of the lift motor in potentiometer units (0 to 1023)

--- a/src/digger/digger/digger_node.py
+++ b/src/digger/digger/digger_node.py
@@ -75,7 +75,7 @@ class DiggerNode(Node):
         # Assign the ROS Parameters to member variables below #
         self.DIGGER_MOTOR = self.get_parameter("DIGGER_MOTOR").value
         # Print the ROS Parameters to the terminal below #
-        self.get_logger().info("DIGGER_MOTOR has been set to: " + str(self.DIGGER_MOTOR))       
+        self.get_logger().info("DIGGER_MOTOR has been set to: " + str(self.DIGGER_MOTOR))
         # Current state of the digger belt
         self.running = False
         # Current position of the lift motor in potentiometer units (0 to 1023)

--- a/src/digger/digger/digger_node.py
+++ b/src/digger/digger/digger_node.py
@@ -72,16 +72,13 @@ class DiggerNode(Node):
 
         # Define default values for our ROS parameters below #
         self.declare_parameter("DIGGER_MOTOR", 3)
-        self.declare_parameter("MAX_POS_DIFF", 3)
-
+        
         # Assign the ROS Parameters to member variables below #
         self.DIGGER_MOTOR = self.get_parameter("DIGGER_MOTOR").value
-        self.MAX_POS_DIFF = self.get_parameter("MAX_POS_DIFF").value
-
+       
         # Print the ROS Parameters to the terminal below #
         self.get_logger().info("DIGGER_MOTOR has been set to: " + str(self.DIGGER_MOTOR))
-        self.get_logger().info("MAX_POS_DIFF has been set to: " + str(self.MAX_POS_DIFF))
-
+       
         # Current state of the digger belt
         self.running = False
         # Current position of the lift motor in potentiometer units (0 to 1023)
@@ -251,14 +248,8 @@ class DiggerNode(Node):
     # Define the subscriber callback for the potentiometers topic
     def pot_callback(self, msg: Potentiometers):
         """Helps us know whether or not the current goal position has been reached."""
-        # Should use the same threshold that is being used in the motor_coontrol_node
-        if abs(msg.left_motor_pot - msg.right_motor_pot) > self.MAX_POS_DIFF:
-            self.get_logger().error("ERROR: The two potentiometer values are too far apart!")
-            self.current_lift_position = None  # We don't know the current position anymore
-            self.stop_lift()  # Stop the lift system
-        else:
-            # Average the two potentiometer values
-            self.current_lift_position = (msg.left_motor_pot + msg.right_motor_pot) / 2
+        # Average the two potentiometer values
+        self.current_lift_position = (msg.left_motor_pot + msg.right_motor_pot) / 2
 
     # Define subscriber callback methods here
     def linear_actuator_current_callback(self, linear_acutator_msg):

--- a/src/motor_control/src/motor_control_node.cpp
+++ b/src/motor_control/src/motor_control_node.cpp
@@ -413,13 +413,28 @@ private:
 
     //RCLCPP_INFO(this->get_logger(), "Error: %d, Adjustment: %f", error, speed_adjustment);
 
-    if (abs(error) > this->get_parameter("MAX_POS_DIFF").as_int()) {
+    if (abs(error) > this->get_parameter("MAX_POS_DIFF").as_int() && strcmp(this->digger_lift_goal.type.c_str(), "position") == 0) {
       // Stop both motors!
       this->digger_lift_goal = { "duty_cycle", 0.0 };
       vesc_set_duty_cycle(this->get_parameter("DIGGER_LEFT_LINEAR_ACTUATOR").as_int(), 0.0);
       vesc_set_duty_cycle(this->get_parameter("DIGGER_RIGHT_LINEAR_ACTUATOR").as_int(), 0.0);
       // Log an error message
       RCLCPP_ERROR(this->get_logger(), "ERROR: Position difference between linear actuators is too high! Stopping both motors.");
+    }
+    else if (abs(error) > this->get_parameter("MAX_POS_DIFF").as_int() && strcmp(this->digger_lift_goal.type.c_str(), "duty_cycle") == 0 && this->digger_lift_goal.value != 0.0) {
+      if (error > 0.0 && this->digger_lift_goal.value > 0.0) {
+        vesc_set_duty_cycle(this->get_parameter("DIGGER_LEFT_LINEAR_ACTUATOR").as_int(), 0.0);
+        vesc_set_duty_cycle(this->get_parameter("DIGGER_RIGHT_LINEAR_ACTUATOR").as_int(), this->digger_lift_goal.value);
+      } else if (error < 0.0 && this->digger_lift_goal.value > 0.0) {
+        vesc_set_duty_cycle(this->get_parameter("DIGGER_LEFT_LINEAR_ACTUATOR").as_int(), this->digger_lift_goal.value);
+        vesc_set_duty_cycle(this->get_parameter("DIGGER_RIGHT_LINEAR_ACTUATOR").as_int(), 0.0);
+      } else if (error > 0.0 && this->digger_lift_goal.value < 0.0) {
+        vesc_set_duty_cycle(this->get_parameter("DIGGER_LEFT_LINEAR_ACTUATOR").as_int(), this->digger_lift_goal.value);
+        vesc_set_duty_cycle(this->get_parameter("DIGGER_RIGHT_LINEAR_ACTUATOR").as_int(), 0.0);
+      } else if (error < 0.0 && this->digger_lift_goal.value < 0.0) {
+        vesc_set_duty_cycle(this->get_parameter("DIGGER_LEFT_LINEAR_ACTUATOR").as_int(), 0.0);
+        vesc_set_duty_cycle(this->get_parameter("DIGGER_RIGHT_LINEAR_ACTUATOR").as_int(), this->digger_lift_goal.value);
+      }
     }
     else if (strcmp(this->digger_lift_goal.type.c_str(), "duty_cycle") == 0 && this->digger_lift_goal.value != 0.0) {
       vesc_set_duty_cycle(this->get_parameter("DIGGER_LEFT_LINEAR_ACTUATOR").as_int(), this->digger_lift_goal.value + speed_adjustment);

--- a/src/motor_control/src/motor_control_node.cpp
+++ b/src/motor_control/src/motor_control_node.cpp
@@ -248,13 +248,6 @@ class MotorControlNode : public rclcpp::Node {
                     std::shared_ptr<rovr_interfaces::srv::MotorCommandSet::Response> response) {
     // Update the current digger lift goal
     this->digger_lift_goal = { request->type, request->value };
-
-    // Set the digger lift motors to the new duty cycle
-    if (strcmp(this->digger_lift_goal.type.c_str(), "duty_cycle") == 0) {
-      vesc_set_duty_cycle(this->get_parameter("DIGGER_LEFT_LINEAR_ACTUATOR").as_int(), this->digger_lift_goal.value);
-      vesc_set_duty_cycle(this->get_parameter("DIGGER_RIGHT_LINEAR_ACTUATOR").as_int(), this->digger_lift_goal.value);
-    }
-
     response->success = true;
   }
 
@@ -422,18 +415,19 @@ private:
       RCLCPP_ERROR(this->get_logger(), "ERROR: Position difference between linear actuators is too high! Stopping both motors.");
     }
     else if (abs(error) > this->get_parameter("MAX_POS_DIFF").as_int() && strcmp(this->digger_lift_goal.type.c_str(), "duty_cycle") == 0 && this->digger_lift_goal.value != 0.0) {
+      RCLCPP_ERROR(this->get_logger(), "ERROR: Position difference between linear actuators is too high!");
       if (error > 0.0 && this->digger_lift_goal.value > 0.0) {
-        vesc_set_duty_cycle(this->get_parameter("DIGGER_LEFT_LINEAR_ACTUATOR").as_int(), 0.0);
-        vesc_set_duty_cycle(this->get_parameter("DIGGER_RIGHT_LINEAR_ACTUATOR").as_int(), this->digger_lift_goal.value);
+        vesc_set_duty_cycle(this->get_parameter("DIGGER_LEFT_LINEAR_ACTUATOR").as_int(), this->digger_lift_goal.value);
+        vesc_set_duty_cycle(this->get_parameter("DIGGER_RIGHT_LINEAR_ACTUATOR").as_int(), 0.0);
       } else if (error < 0.0 && this->digger_lift_goal.value > 0.0) {
-        vesc_set_duty_cycle(this->get_parameter("DIGGER_LEFT_LINEAR_ACTUATOR").as_int(), this->digger_lift_goal.value);
-        vesc_set_duty_cycle(this->get_parameter("DIGGER_RIGHT_LINEAR_ACTUATOR").as_int(), 0.0);
-      } else if (error > 0.0 && this->digger_lift_goal.value < 0.0) {
-        vesc_set_duty_cycle(this->get_parameter("DIGGER_LEFT_LINEAR_ACTUATOR").as_int(), this->digger_lift_goal.value);
-        vesc_set_duty_cycle(this->get_parameter("DIGGER_RIGHT_LINEAR_ACTUATOR").as_int(), 0.0);
-      } else if (error < 0.0 && this->digger_lift_goal.value < 0.0) {
         vesc_set_duty_cycle(this->get_parameter("DIGGER_LEFT_LINEAR_ACTUATOR").as_int(), 0.0);
         vesc_set_duty_cycle(this->get_parameter("DIGGER_RIGHT_LINEAR_ACTUATOR").as_int(), this->digger_lift_goal.value);
+      } else if (error > 0.0 && this->digger_lift_goal.value < 0.0) {
+        vesc_set_duty_cycle(this->get_parameter("DIGGER_LEFT_LINEAR_ACTUATOR").as_int(), 0.0);
+        vesc_set_duty_cycle(this->get_parameter("DIGGER_RIGHT_LINEAR_ACTUATOR").as_int(), this->digger_lift_goal.value);
+      } else if (error < 0.0 && this->digger_lift_goal.value < 0.0) {
+        vesc_set_duty_cycle(this->get_parameter("DIGGER_LEFT_LINEAR_ACTUATOR").as_int(), this->digger_lift_goal.value);
+        vesc_set_duty_cycle(this->get_parameter("DIGGER_RIGHT_LINEAR_ACTUATOR").as_int(), 0.0);
       }
     }
     else if (strcmp(this->digger_lift_goal.type.c_str(), "duty_cycle") == 0 && this->digger_lift_goal.value != 0.0) {


### PR DESCRIPTION
This needs to be tested before reviewing & merging this PR, but the goal is to still allow manual control of ONE digger linear actuator when MAX_POS_DIFF has been reached so that reaching MAX_POS_DIFF is not a match killer and can be manually fixed.