### PR TITLE
Fix basic navigator embedded in another node

### DIFF
--- a/src/rovr_interfaces/CMakeLists.txt
+++ b/src/rovr_interfaces/CMakeLists.txt
@@ -22,6 +22,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "action/AutoDig.action"
   "action/AutoOffload.action"
   "action/CalibrateFieldCoordinates.action"
+  "action/GoToDigLocation.action"
   "msg/LimitSwitches.msg"
   "msg/Potentiometers.msg"
   "srv/Drive.srv"

--- a/src/rovr_interfaces/action/GoToDigLocation.action
+++ b/src/rovr_interfaces/action/GoToDigLocation.action
@@ -1,0 +1,5 @@
+# Request
+---
+# Result
+---
+# Feedback


### PR DESCRIPTION
Currently when dig location server is run it works fine but when launched in a launch file the following error occurs
```
[dig_location_server-1] [WARN] [1744559437.261580236] [rcl.logging_rosout]: Publisher already registered for provided node name. If this is due to multiple nodes with the same name then all logs for that logger name will go out over the existing publisher. As soon as any node with that name is destructed it will unregister the publisher, preventing any further logs for that name from being published on the rosout topic.
```
this fixes it