### PR TITLE
joystick will now be recognized without having to replug it

### DIFF
--- a/scripts/enter_isaac_ros_container.sh
+++ b/scripts/enter_isaac_ros_container.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 printf 'CONFIG_DOCKER_SEARCH_DIRS="$HOME/Lunabotics/src/isaac_ros/isaac_ros_common/scripts/../../../../docker"\n BASE_DOCKER_REGISTRY_NAMES="umnrobotics/isaac_ros3.1"\n'> ~/.isaac_ros_common-config
 image_key="ros2_humble.deepstream.user.zed.umn.gazebo"
-docker_arg="-v /usr/local/zed/resources:/usr/local/zed/resources -v $HOME/rosbags:/rosbags -v /usr/local/zed/settings:/usr/local/zed/settings"
+docker_arg="-v /dev/input:/dev/input -v /usr/local/zed/resources:/usr/local/zed/resources -v $HOME/rosbags:/rosbags -v /usr/local/zed/settings:/usr/local/zed/settings"
 
 USE_CACHED_IMAGE=${1:-true}
 


### PR DESCRIPTION
The solution is to just have the docker image use the actual /dev/input directory on your system. This may be unsafe but because it allows the docker image to see your actual file system but non of the code we are running is foreign or potentially malicious so it theoretically shouldn't matter. This should definitely be tested.